### PR TITLE
Add vakint to symbolica community.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "joinery"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1145,49 @@ checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1564,6 +1613,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_lisp"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c5734eceb60a15465bc85cafe540f454b79e23732bf56f913d081d9ae008ee"
+dependencies = [
+ "cfg-if",
+ "libm",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,6 +1774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +1901,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string-template-plus"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d12beb34a053c22eea5ebeaeb9a3cf8297044184f38194d4b2cdb057d1a6a2"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "colored 2.2.0",
+ "lazy_static",
+ "regex",
+ "rust_lisp",
+ "subprocess",
+ "titlecase",
+]
+
+[[package]]
+name = "subprocess"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "symbolica"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,9 +1990,11 @@ version = "0.18.0"
 dependencies = [
  "idenso",
  "pyo3",
+ "pyo3-build-config",
  "pyo3-stub-gen",
  "spynso3",
  "symbolica 0.18.0",
+ "vakint",
 ]
 
 [[package]]
@@ -2028,6 +2121,17 @@ name = "tinyjson"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a"
+
+[[package]]
+name = "titlecase"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38397a8cdb017cfeb48bf6c154d6de975ac69ffeed35980fde199d2ee0842042"
+dependencies = [
+ "joinery",
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "toml"
@@ -2207,6 +2311,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vakint"
+version = "1.0.0"
+source = "git+https://github.com/alphal00p/vakint?rev=5877366f652a397924fd5b6d77ef690941ac2881#5877366f652a397924fd5b6d77ef690941ac2881"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "arrayvec",
+ "colored 2.2.0",
+ "log",
+ "phf",
+ "pyo3",
+ "pyo3-stub-gen",
+ "regex",
+ "rug",
+ "string-template-plus",
+ "symbolica 0.18.0",
+ "thiserror 1.0.69",
+ "version-compare",
+]
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,6 +2440,28 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ python_stubgen = [
     "symbolica/python_stubgen",
     "spynso3/python_stubgen",
     "idenso/python_stubgen",
+    "vakint/python_stubgen",
 ]
 
 [dependencies]
@@ -32,6 +33,10 @@ symbolica = { version = "0.18", features = ["python_export"] }
 pyo3 = "0.25"
 pyo3-stub-gen = { version = "0.13", default-features = false }
 spynso3 = { git = "https://github.com/alphal00p/spenso", package = "spynso3", rev = "66843203a8eb3ef473d91d31fc37ad8c43ea9f20" }
+vakint = { git = "https://github.com/alphal00p/vakint", rev = "5877366f652a397924fd5b6d77ef690941ac2881", features = [
+    "symbolica_community_module",
+    "python_stubgen",
+] }
 
 [patch.crates-io]
 
@@ -39,3 +44,6 @@ idenso = { git = "https://github.com/alphal00p/spenso", rev = "66843203a8eb3ef47
 spenso = { git = "https://github.com/alphal00p/spenso", rev = "66843203a8eb3ef473d91d31fc37ad8c43ea9f20" }
 symbolica = { git = "https://github.com/benruijl/symbolica", branch = "modules" }
 pyo3-stub-gen = { git = "https://github.com/benruijl/pyo3-stub-gen", branch = "patched" }
+
+[build-dependencies]
+pyo3-build-config = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ fn core(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     register_extension::<idenso::python::IdensoModule>(m)?;
     register_extension::<spynso3::SpensoModule>(m)?;
+    register_extension::<vakint::symbolica_community_module::VakintWrapper>(m)?;
 
     Ok(())
 }


### PR DESCRIPTION
I tested that:

```
cargo run --features "python_stubgen" # generate type hints
maturin build --release
```

both successfully complete, and the stub file:
```
python/symbolica/community/vakint.pyi
```
is generated (but with useless content for now, @benruijl you'll have to teach me how to use pystub_gen properly).

Moreover, I then successfully ran my test python code:


```python3
from symbolica.community.vakint import Vakint, VakintEvaluationMethod, VakintExpression, VakintNumericalResult
from symbolica import E, S

masses = {"muvsq": 2., "mursq": 3.}
external_momenta = {
    1: (0.1, 0.2, 0.3, 0.4),
    2: (0.5, 0.6, 0.7, 0.8)
}

# FIX: on my setup, the code below triggers an "out of bound" python crash
# eo = [ VakintEvaluationMethod.new_alphaloop_method() ]
# to_fix = vakint = Vakint(evaluation_order=eo)

# It is of course possible to use defaults only, with
# vakint = Vakint()
vakint = Vakint(
    integral_normalization_factor="MSbar",
    mu_r_sq_symbol=S("mursq"),
    # If you select 5 terms, then MATAD will be used, but for 4 and fewer, alphaLoop is will be used as
    # it is first in the evaluation_order supplied.
    number_of_terms_in_epsilon_expansion=4,
    evaluation_order=[
        VakintEvaluationMethod.new_alphaloop_method(),
        VakintEvaluationMethod.new_matad_method(),
        VakintEvaluationMethod.new_fmft_method(),
        # VakintEvaluationMethod.new_pysecdec_method(
        #     min_n_evals=10_000,
        #     max_n_evals=1000_000,
        #     numerical_masses=masses,
        #     numerical_external_momenta=external_momenta
        # ),
    ],
    form_exe_path="form",
    python_exe_path="python3",
)

integral = E("""
        ( 
            k(1,11)*k(2,11)*k(1,22)*k(2,22)
          + p(1,11)*k(3,11)*k(3,22)*p(2,22)
          + p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
        )*topo(
             prop(1,edge(1,2),k(1),muvsq,1)
            * prop(2,edge(2,3),k(2),muvsq,1)
            * prop(3,edge(3,1),k(3),muvsq,1)
            * prop(4,edge(1,4),k(3)-k(1),muvsq,1)
            * prop(5,edge(2,4),k(1)-k(2),muvsq,1)
            * prop(6,edge(3,4),k(2)-k(3),muvsq,1)
)""", default_namespace="vakint")
print(f"\nStarting integral:\n{VakintExpression(integral)}")

canonical_integral = vakint.to_canonical(integral, short_form=True)
print(f"\nCanonical integral:\n{VakintExpression(canonical_integral)}")

tensor_reduced_integral = vakint.tensor_reduce(canonical_integral)
print(f"\nTensor reduced integral:\n{
      VakintExpression(tensor_reduced_integral)}")

evaluated_integral = vakint.evaluate_integral(tensor_reduced_integral)
print(f"\nEvaluated integral:\n{evaluated_integral}")

# Direct evaluation all at once
direct_evaluation = vakint.evaluate(integral)

assert direct_evaluation == evaluated_integral

num_eval, num_error = vakint.numerical_evaluation(
    evaluated_integral, params=masses, externals=external_momenta)

print(f"\nNumerical evaluation:\n{num_eval}")

print(f"\nNumerical evaluation as list:\n{num_eval.to_list()}")

# FIX: on my setup, the code below triggers an "out of bound" python crash, similar to before for new Vakint() setup
print(f"\nNumerical evaluation, as expression:\n{vakint.numerical_result_to_expression(num_eval)}")  # nopep8

benchmark = VakintNumericalResult([
    (-3, (0.0, -11440.53140354612)),
    (-2, (0.0,  57169.95521898031)),
    (-1, (0.0, -178748.9838377694)),
    (-0, (0.0,  321554.1122184795)),
])

match_res, match_msg = benchmark.compare_to(
    num_eval, relative_threshold=1.0e-10
)

print(f"\nMatch result: {match_res}, {match_msg}")

assert match_res
```