### PR TITLE
Update GammaLoop for symbolic parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "gammaloop-workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/alphal00p/gammaloop?rev=d1f99ffab783715050fe5fd1de676670d7f3e2aa#d1f99ffab783715050fe5fd1de676670d7f3e2aa"
+source = "git+https://github.com/alphal00p/gammaloop?rev=fff1d66ee7ca039b9e165fe8d29da91f4c27113c#fff1d66ee7ca039b9e165fe8d29da91f4c27113c"
 dependencies = [
  "ahash",
  "anstream",
@@ -1168,7 +1168,7 @@ dependencies = [
 [[package]]
 name = "idenso"
 version = "0.3.0"
-source = "git+https://github.com/alphal00p/gammaloop?rev=d1f99ffab783715050fe5fd1de676670d7f3e2aa#d1f99ffab783715050fe5fd1de676670d7f3e2aa"
+source = "git+https://github.com/alphal00p/gammaloop?rev=fff1d66ee7ca039b9e165fe8d29da91f4c27113c#fff1d66ee7ca039b9e165fe8d29da91f4c27113c"
 dependencies = [
  "base64",
  "bincode",
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "linnet"
 version = "0.17.0"
-source = "git+https://github.com/alphal00p/gammaloop?rev=d1f99ffab783715050fe5fd1de676670d7f3e2aa#d1f99ffab783715050fe5fd1de676670d7f3e2aa"
+source = "git+https://github.com/alphal00p/gammaloop?rev=fff1d66ee7ca039b9e165fe8d29da91f4c27113c#fff1d66ee7ca039b9e165fe8d29da91f4c27113c"
 dependencies = [
  "ahash",
  "bincode",
@@ -2682,7 +2682,7 @@ checksum = "02ef091d4e8b981dbaa4cc17789d00b53d5d2c001ae689f14e6093f30c529036"
 [[package]]
 name = "spenso"
 version = "0.6.0"
-source = "git+https://github.com/alphal00p/gammaloop?rev=d1f99ffab783715050fe5fd1de676670d7f3e2aa#d1f99ffab783715050fe5fd1de676670d7f3e2aa"
+source = "git+https://github.com/alphal00p/gammaloop?rev=fff1d66ee7ca039b9e165fe8d29da91f4c27113c#fff1d66ee7ca039b9e165fe8d29da91f4c27113c"
 dependencies = [
  "ahash",
  "append-only-vec",
@@ -2726,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "spenso-hep-lib"
 version = "0.1.7"
-source = "git+https://github.com/alphal00p/gammaloop?rev=d1f99ffab783715050fe5fd1de676670d7f3e2aa#d1f99ffab783715050fe5fd1de676670d7f3e2aa"
+source = "git+https://github.com/alphal00p/gammaloop?rev=fff1d66ee7ca039b9e165fe8d29da91f4c27113c#fff1d66ee7ca039b9e165fe8d29da91f4c27113c"
 dependencies = [
  "ahash",
  "gammaloop-workspace-hack",
@@ -2740,7 +2740,7 @@ dependencies = [
 [[package]]
 name = "spenso-macros"
 version = "0.3.2"
-source = "git+https://github.com/alphal00p/gammaloop?rev=d1f99ffab783715050fe5fd1de676670d7f3e2aa#d1f99ffab783715050fe5fd1de676670d7f3e2aa"
+source = "git+https://github.com/alphal00p/gammaloop?rev=fff1d66ee7ca039b9e165fe8d29da91f4c27113c#fff1d66ee7ca039b9e165fe8d29da91f4c27113c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "spynso3"
 version = "0.1.2"
-source = "git+https://github.com/alphal00p/gammaloop?rev=d1f99ffab783715050fe5fd1de676670d7f3e2aa#d1f99ffab783715050fe5fd1de676670d7f3e2aa"
+source = "git+https://github.com/alphal00p/gammaloop?rev=fff1d66ee7ca039b9e165fe8d29da91f4c27113c#fff1d66ee7ca039b9e165fe8d29da91f4c27113c"
 dependencies = [
  "ahash",
  "eyre",
@@ -3425,7 +3425,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "vakint"
 version = "0.1.2"
-source = "git+https://github.com/alphal00p/gammaloop?rev=d1f99ffab783715050fe5fd1de676670d7f3e2aa#d1f99ffab783715050fe5fd1de676670d7f3e2aa"
+source = "git+https://github.com/alphal00p/gammaloop?rev=fff1d66ee7ca039b9e165fe8d29da91f4c27113c#fff1d66ee7ca039b9e165fe8d29da91f4c27113c"
 dependencies = [
  "ahash",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ pyo3-stub-gen = { version = "0.17", optional = true, default-features = false, f
     "numpy",
 ] }
 spynso3 = { version = "0.1" }
-vakint = { git = "https://github.com/alphal00p/gammaloop", rev = "d1f99ffab783715050fe5fd1de676670d7f3e2aa", features = [
+vakint = { git = "https://github.com/alphal00p/gammaloop", rev = "fff1d66ee7ca039b9e165fe8d29da91f4c27113c", features = [
     "symbolica_community_module",
 ] }
 mimalloc = { version = "0.1", features = [
@@ -50,10 +50,10 @@ mimalloc = { version = "0.1", features = [
 ] } # prevent TLS allocation errors in conjunction with numpy
 
 [patch.crates-io]
-spynso3 = { git = "https://github.com/alphal00p/gammaloop", rev = "d1f99ffab783715050fe5fd1de676670d7f3e2aa" }
-idenso = { git = "https://github.com/alphal00p/gammaloop", rev = "d1f99ffab783715050fe5fd1de676670d7f3e2aa" }
-spenso = { git = "https://github.com/alphal00p/gammaloop", rev = "d1f99ffab783715050fe5fd1de676670d7f3e2aa" }
-spenso-hep-lib = { git = "https://github.com/alphal00p/gammaloop", rev = "d1f99ffab783715050fe5fd1de676670d7f3e2aa" }
+spynso3 = { git = "https://github.com/alphal00p/gammaloop", rev = "fff1d66ee7ca039b9e165fe8d29da91f4c27113c" }
+idenso = { git = "https://github.com/alphal00p/gammaloop", rev = "fff1d66ee7ca039b9e165fe8d29da91f4c27113c" }
+spenso = { git = "https://github.com/alphal00p/gammaloop", rev = "fff1d66ee7ca039b9e165fe8d29da91f4c27113c" }
+spenso-hep-lib = { git = "https://github.com/alphal00p/gammaloop", rev = "fff1d66ee7ca039b9e165fe8d29da91f4c27113c" }
 
 symbolica = { git = "https://github.com/symbolica-dev/symbolica", branch = "main" }
 numerica = { git = "https://github.com/symbolica-dev/symbolica", branch = "main" }

--- a/python/symbolica/community/spenso/__init__.pyi
+++ b/python/symbolica/community/spenso/__init__.pyi
@@ -1969,6 +1969,24 @@ class ExecutionMode(enum.Enum):
     All = ...
 
 @typing.final
+class SymbolicParallelism(enum.Enum):
+    r"""
+    Policy for Rayon operations that manipulate Symbolica expressions.
+    """
+    Auto = ...
+    r"""
+    Resolve the setting from the Symbolica license when configured.
+    """
+    Serial = ...
+    r"""
+    Keep symbolic operations on the calling thread.
+    """
+    Parallel = ...
+    r"""
+    Allow symbolic operations to use Rayon workers.
+    """
+
+@typing.final
 class TensorNamespace(enum.Enum):
     r"""
     Enumeration for different tensor namespaces in physics.
@@ -1985,3 +2003,10 @@ class TensorNamespace(enum.Enum):
 
 def initialize() -> None: ...
 
+def set_symbolica_rayon_enabled(policy: SymbolicParallelism) -> builtins.bool:
+    r"""
+    Configure whether Spenso may use Rayon for Symbolica operations.
+
+    `Auto` checks the Symbolica license once during this call. Tensor operations
+    subsequently use the cached result without querying the license again.
+    """


### PR DESCRIPTION
## Summary

- update the five GammaLoop dependency revisions to merged main `fff1d66ee7ca039b9e165fe8d29da91f4c27113c`
- refresh only the eight corresponding GammaLoop sources in `Cargo.lock`
- expose `SymbolicParallelism` and `set_symbolica_rayon_enabled` in the checked-in Spenso type stub

This brings in the cached symbolic-Rayon policy from alphal00p/gammaloop#92 without restructuring the dependency manifest.

## Validation

- `cargo check --locked`
- `cargo run --locked --no-default-features --features python_stubgen --bin stub_gen`
- verified the generated enum/setter declarations match the checked-in stub
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
